### PR TITLE
fix user registration

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/AuthController.php
+++ b/backend/app/Http/Controllers/Api/V1/AuthController.php
@@ -43,7 +43,7 @@ class AuthController extends Controller {
             'role' => $request->role,
             'status' => UserStatus::ACTIVE,
             'email' => $request->email,
-            'password' => bcrypt($request->password),
+            'password' => $request->password,
         ]);
 
         $userToken = $user->createToken('appToken');


### PR DESCRIPTION
## Changes Made

- Remove redundant hashing in register

## Purpose

Newly registered users was not able to login because password was hashed twice.

## Related Task/Issue

[Slack Link](https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1709861939250659)
[Ticket Link](https://framgiaph.backlog.com/view/SBNB-39)

## Screenshots

N/A

## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/A
