### PR TITLE
Allow return of empty array for calendar

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/CalendarController.php
+++ b/backend/app/Http/Controllers/Api/V1/CalendarController.php
@@ -12,10 +12,6 @@ class CalendarController extends Controller {
         try {
             $calendarDates = Calendar::where('listing_id', $listingId)->get();
 
-            if ($calendarDates->isEmpty()) {
-                return response()->json(['message' => 'Listing does not have any calendar availability data.'], Response::HTTP_NOT_FOUND);
-            }
-
             return response()->json(['calendar_dates' => $calendarDates], Response::HTTP_OK);
         } catch (\Exception $e) {
             return response()->json(['message' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## Changes Made
- removed condition where it will return an error message to instead return an empty array instead

## Purpose
- to allow calendar dates to not throw an error when there are no dates set.

## Related Task/Issue
- Slack Link: https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1710222705897219
- Task Link: https://framgiaph.backlog.com/view/SBNB-60

## Screenshots
N/A

## New Dependencies (if applicable)
N/A

## Additional Information (if applicable)
N/A