### PR TITLE
Update listing to display newest to oldest

### DIFF
--- a/backend/app/Models/Listing.php
+++ b/backend/app/Models/Listing.php
@@ -159,6 +159,7 @@ class Listing extends Model {
         $perPage = $request->query('per_page', 3);
 
         $query = self::$filterMethod($filters, $userId);
+        $query->orderBy('updated_at', 'desc')->orderBy('created_at', 'desc');
 
         return $query->paginate($perPage);
     }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -37,7 +37,7 @@ Route::group(['prefix' => 'register'], function () {
 
 Route::post('/forget-password', [PasswordController::class, 'forgotpassword']);
 Route::post('/reset-password', [PasswordController::class, 'resetpassword']);
-Route::get('/public-listingss', [ListingController::class, 'showPublicListings']);
+Route::get('/public-listings', [ListingController::class, 'showPublicListings']);
 Route::get('/public-accommodations', [ListingController::class, 'showPublicAccommodations']);
 Route::get('/public-experiences', [ListingController::class, 'showPublicExperiences']);
 Route::get('/listing/{listingId}', [ListingController::class, 'show']);


### PR DESCRIPTION
## Changes Made

- Updated listing display behavior to display newest to oldest.

## Purpose

To enhance user experience by ensuring that the most current listings are displayed first.

## Related Task/Issue

- [Slack Link](https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1711516137597219)
- [Task Link](https://framgiaph.backlog.com/view/SBNB-106)

## Screenshots

![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/07cd16cd-6ea2-4c5e-8f91-c4105c5ae6ee)
![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/b2279ab9-8757-4c7b-90bf-775423eb176f)

## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/A
