### PR TITLE
allow booking for active listings only

### DIFF
--- a/backend/app/Models/Booking.php
+++ b/backend/app/Models/Booking.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\BookingStatus;
+use App\Enums\ListingStatus;
 use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -47,6 +48,7 @@ class Booking extends Model {
 
     public static function createBooking($request): self {
         $listing = Listing::findOrFail($request->listing_id);
+        abort_unless($listing->status === ListingStatus::ACTIVE, Response::HTTP_BAD_REQUEST, 'Listing is not available for booking.');
 
         $booking = new Booking($request->only(['start_date', 'end_date', 'number_of_guests']));
         $booking->user()->associate(auth()->user());
@@ -138,8 +140,10 @@ class Booking extends Model {
             abort(Response::HTTP_BAD_REQUEST, 'Invalid action provided');
         }
 
-        if (! in_array($this->status, [BookingStatus::PENDING, BookingStatus::UPCOMING]) ||
-        ($this->status === BookingStatus::UPCOMING && $action === 'approve')) {
+        if (
+            ! in_array($this->status, [BookingStatus::PENDING, BookingStatus::UPCOMING]) ||
+            ($this->status === BookingStatus::UPCOMING && $action === 'approve')
+        ) {
             abort(Response::HTTP_BAD_REQUEST, 'Booking cannot be '.$action.'d.');
         }
 


### PR DESCRIPTION
## Changes Made

- add booking restrictions to only book active listings

## Purpose

- guest cannot book a listing if it is not yet approved

## Related Task/Issue

- Slack Link: https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1711519122120609
- Task Link: https://framgiaph.backlog.com/view/SBNB-107

## Screenshots

![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/12a23855-546f-4bbc-b4fd-1e1dc4ade5d7)

## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/A
