### PR TITLE
update restrictions on booking dates

### DIFF
--- a/backend/app/Http/Requests/V1/BookingRequest.php
+++ b/backend/app/Http/Requests/V1/BookingRequest.php
@@ -22,7 +22,7 @@ class BookingRequest extends FormRequest {
      */
     public function rules(): array {
         return [
-            'start_date' => 'required|date|after:today',
+            'start_date' => 'required|date|after_or_equal:today',
             'end_date' => [
                 'required',
                 'date',

--- a/backend/app/Rules/MinMaxDaysRule.php
+++ b/backend/app/Rules/MinMaxDaysRule.php
@@ -30,5 +30,11 @@ class MinMaxDaysRule implements DataAwareRule, ValidationRule {
                 );
             }
         }
+
+        if ($listing && $listing->listable_type === 'App\Models\Experience') {
+            if ($numberOfDays !== 0) {
+                $fail('The number of days should be 0 for experiences.');
+            }
+        }
     }
 }


### PR DESCRIPTION
## Changes Made

- Start dates should be today or after
- Experiences should be book per day

## Purpose

Make the input request are valid before booking.

## Related Task/Issue

- Slack Link: https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1711954810343589
- Task Link: https://framgiaph.backlog.com/view/SBNB-111

## Screenshots

![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/12b6e430-2e1b-45f2-991c-8f40d60b4215)

## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/A
