### PR TITLE
Allow decimal for price input in create/edit listings

### DIFF
--- a/frontend/src/app/(guest)/experiences/[id]/page.tsx
+++ b/frontend/src/app/(guest)/experiences/[id]/page.tsx
@@ -52,6 +52,7 @@ const GuestExperienceDetailsPage: React.FC<
             barangay={expData.barangay}
             city={expData.city}
             type={expData.listable.type}
+            price={expData.price}
             zipCode={expData.zip_code}
             languages={expData.listable.language}
             startTime={expData.listable.start_time}

--- a/frontend/src/app/(host)/listings/PriceForm.tsx
+++ b/frontend/src/app/(host)/listings/PriceForm.tsx
@@ -21,15 +21,15 @@ const PriceForm: React.FC<PriceFormProps> = ({ data, setData, error }) => {
           className="mt-4"
           startContent="₱"
           variant="bordered"
-          placeholder="0"
+          placeholder="0.00"
           isInvalid={error.hasError === true && data.price < 1}
           value={data.price.toString() === "0" ? "" : data.price.toString()}
           onChange={(e) => {
-            const inputValue = e.target.value;
-            if (inputValue === "0" || inputValue === "") {
+            const inputValue = parseFloat(e.target.value);
+            if (!isNaN(inputValue)) {
+              setData({ ...data, price: inputValue });
+            } else {
               setData({ ...data, price: 0 });
-            } else if (!isNaN(parseInt(inputValue))) {
-              setData({ ...data, price: parseInt(inputValue) });
             }
           }}
         />

--- a/frontend/src/app/(host)/listings/accommodations/[id]/page.tsx
+++ b/frontend/src/app/(host)/listings/accommodations/[id]/page.tsx
@@ -39,6 +39,7 @@ const AccommodationDetailsPage: React.FC<ListingDetailsPageProps> = async ({
             accomodationName={accData.name}
             type={accData.listable.type}
             city={accData.city}
+            price={accData.price}
             guests={accData.maximum_guests}
             bedrooms={accData.listable.bedroom_count}
             beds={accData.listable.bed_count}

--- a/frontend/src/app/(host)/listings/experiences/[id]/page.tsx
+++ b/frontend/src/app/(host)/listings/experiences/[id]/page.tsx
@@ -38,6 +38,7 @@ const ExperienceDetailsPage: React.FC<ExperienceDetailsProps> = async ({
         barangay={expData.barangay}
         city={expData.city}
         type={expData.listable.type}
+        price={expData.price}
         zipCode={expData.zip_code}
         languages={expData.listable.language}
         startTime={expData.listable.start_time}

--- a/frontend/src/app/components/accommodation/ListingHeader.tsx
+++ b/frontend/src/app/components/accommodation/ListingHeader.tsx
@@ -18,6 +18,7 @@ interface ListingHeaderProps {
   maximumNights: number;
   type: string;
   city: string;
+  price: number;
   hostName: string;
   createdAt: string;
   modifiedAt: string;
@@ -36,6 +37,7 @@ const ListingHeader: React.FC<ListingHeaderProps> = async ({
   maximumNights,
   type,
   city,
+  price,
   address,
   hostName,
   createdAt,
@@ -48,13 +50,13 @@ const ListingHeader: React.FC<ListingHeaderProps> = async ({
   }
   return (
     <div>
-      <div className="mb-2 flex items-center justify-between">
+      <div className="mb-4 flex items-center justify-between">
         <div className="flex flex-row">
-          <span className="text-lg font-bold leading-7">
+          <span className="text-2xl font-bold leading-7">
             {accomodationName}
           </span>
           {(await checkIsHost()) && (
-            <div className="mx-2">
+            <div className="mx-4">
               <StatusChip status={status} />
             </div>
           )}
@@ -92,9 +94,13 @@ const ListingHeader: React.FC<ListingHeaderProps> = async ({
         </div>
       </div>
       <div className="mb-10">
-        <div className="mb-1 text-xl font-semibold leading-7">
-          {type} in {city}
+        <div className="mb-1 flex justify-between text-xl font-semibold leading-7">
+          <span>
+            {type} in {city}
+          </span>
+          <span>₱{price}</span>
         </div>
+
         <div className="mb-1 text-base leading-6 text-zinc-500">
           {guests > 1 ? guests + " Guests" : "1 Guest"} •{" "}
           {bedrooms > 1 ? bedrooms + " Bedrooms" : "1 Bedroom"} •{" "}

--- a/frontend/src/app/components/booking/DefaultSticky.tsx
+++ b/frontend/src/app/components/booking/DefaultSticky.tsx
@@ -13,7 +13,7 @@ const DefaultSticky: React.FC<DefaultStickyProps> = ({ ForAccommodation }) => {
       <div className="w-80">
         <div className="mb-1 w-full rounded-xl border border-1 border-black p-5 shadow-lg">
           <div className="flex w-full justify-center p-2">
-            <span className="w-full text-center text-2xl font-bold">
+            <span className="w-full text-center text-lg font-bold">
               You must login to book{" "}
               {ForAccommodation ? "accommodations" : "experiences"}.
             </span>

--- a/frontend/src/app/components/experience/ExperienceHeader.tsx
+++ b/frontend/src/app/components/experience/ExperienceHeader.tsx
@@ -16,6 +16,7 @@ interface ExperienceHeaderProps {
   barangay: string;
   city: string;
   type: string;
+  price: number;
   zipCode: number;
   languages: string[];
   startTime: string;
@@ -34,6 +35,7 @@ const ExperienceHeader: React.FC<ExperienceHeaderProps> = async ({
   barangay,
   city,
   type,
+  price,
   zipCode,
   languages,
   startTime,
@@ -59,11 +61,11 @@ const ExperienceHeader: React.FC<ExperienceHeaderProps> = async ({
 
   return (
     <div>
-      <div className="mb-2 flex items-center justify-between">
+      <div className="mb-4 flex items-center justify-between">
         <div className="flex">
-          <span className="text-lg font-bold leading-7">{experienceName}</span>
+          <span className="text-2xl font-bold leading-7">{experienceName}</span>
           {(await checkIsHost()) && (
-            <div>
+            <div className="mx-4">
               <StatusChip status={status} />
             </div>
           )}
@@ -103,8 +105,11 @@ const ExperienceHeader: React.FC<ExperienceHeaderProps> = async ({
         </div>
       </div>
       <div className="mb-10">
-        <div className="mb-1 text-xl font-semibold leading-7">
-          {street}, {barangay}, {city}, {zipCode}
+        <div className="mb-1 flex justify-between text-xl font-semibold leading-7">
+          <span>
+            {street}, {barangay}, {city}, {zipCode}
+          </span>
+          {(await checkIsHost()) && <span>₱{price}</span>}
         </div>
         <div className="mb-1 text-base leading-6 text-zinc-500">
           {type} •{" "}

--- a/frontend/src/app/components/experience/ExperiencePriceForm.tsx
+++ b/frontend/src/app/components/experience/ExperiencePriceForm.tsx
@@ -1,10 +1,10 @@
-import type { Experience } from "@/app/interfaces/ExperienceData";
+import type { ExperienceData } from "@/app/interfaces/ExperienceData";
 import { Input } from "@nextui-org/react";
 import React from "react";
 
 interface PriceFormProps {
-  data: Experience;
-  setData: React.Dispatch<React.SetStateAction<Experience>>;
+  data: ExperienceData;
+  setData: React.Dispatch<React.SetStateAction<ExperienceData>>;
   error: Record<string, string | boolean>;
 }
 
@@ -29,11 +29,11 @@ const ExperiencePriceForm: React.FC<PriceFormProps> = ({
           isInvalid={error.hasError === true && data.price < 1}
           value={data.price.toString() === "0" ? "" : data.price.toString()}
           onChange={(e) => {
-            const inputValue = e.target.value;
-            if (inputValue === "0" || inputValue === "") {
+            const inputValue = parseFloat(e.target.value);
+            if (!isNaN(inputValue)) {
+              setData({ ...data, price: inputValue });
+            } else {
               setData({ ...data, price: 0 });
-            } else if (!isNaN(parseInt(inputValue))) {
-              setData({ ...data, price: parseInt(inputValue) });
             }
           }}
         />


### PR DESCRIPTION
## Changes Made

- Updated price input for both create and edit listings (accommodations and experiences) to allow decimals.
- Updated specific accommodation and experience to display the price.
- Modified some design (font size, margin, etc.)

## Purpose

To enhance user experience by allowing decimals in price inputs and refining some design elements for improved aesthetics and usability.

## Related Task/Issue

Link to the related task or issue that prompted these changes.

- [Slack Link](https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1712039408619469)
- [Task Link](https://framgiaph.backlog.com/view/SBNB-114)

## Screenshots

![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/043fc325-0bf5-45c6-af00-f10a2db4b84a)
![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/9440a9e2-83dd-434f-8cd6-85c095f6b12d)
![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/75208d66-9f5a-44e4-aa34-1b326ef4a42d)

## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/A
