### PR TITLE
add admin analytics funtionality

### DIFF
--- a/frontend/src/app/(admin)/dashboard/AdminAnalytics.tsx
+++ b/frontend/src/app/(admin)/dashboard/AdminAnalytics.tsx
@@ -2,6 +2,7 @@ import ListingDoughnut from "@/app/components/admin/ListingDoughnut";
 import BookingsIcon from "@/app/components/svgs/Admin/BookingsIcon";
 import ListingsIcon from "@/app/components/svgs/Admin/ListingsIcon";
 import UsersIcon from "@/app/components/svgs/Admin/UsersIcon";
+import { formatCurrency } from "@/app/utils/currency";
 import React from "react";
 
 interface AnalyticsProps {
@@ -14,6 +15,7 @@ interface AnalyticsProps {
   accumulatedVal: number;
   approvedListings: number;
 }
+
 const AdminAnalytics: React.FC<AnalyticsProps> = ({
   usersCount,
   hostsCount,
@@ -27,7 +29,7 @@ const AdminAnalytics: React.FC<AnalyticsProps> = ({
   return (
     <div>
       <div className="h-96">
-        <div className="my-5 flex h-1/2 w-full flex-row">
+        <div className="mt-3 flex h-1/2 w-full flex-row">
           <div className="mr-2 flex w-1/4 flex-col items-center self-center bg-primary p-4 text-white">
             <div className="m-2">
               <UsersIcon />
@@ -80,7 +82,10 @@ const AdminAnalytics: React.FC<AnalyticsProps> = ({
               <span className="text-xl font-bold">Accumulated value</span>
               <div className="mt-5 flex w-full items-center justify-center self-center text-2xl">
                 <span className="text-4xl">
-                  ₱<span className="font-bold"> {accumulatedVal}</span>
+                  ₱
+                  <span className="font-bold">
+                    {` ${formatCurrency("PHP", 2, accumulatedVal).substring(1)}`}
+                  </span>
                 </span>
               </div>
             </div>

--- a/frontend/src/app/(admin)/dashboard/page.tsx
+++ b/frontend/src/app/(admin)/dashboard/page.tsx
@@ -1,70 +1,11 @@
 import React from "react";
 import AdminAnalytics from "./AdminAnalytics";
-import type { Listing } from "@/app/interfaces/types";
-import { ListingStatus, UserRole } from "@/app/utils/enums";
 import PopularListings from "@/app/components/admin/PopularListingsSection";
 import UserTrafficSection from "@/app/components/admin/UserTrafficSection";
+import { getAdminAnalytics } from "@/app/utils/helpers/adminHelper";
 
-const DashboardPage: React.FC = () => {
-  const dummyListing: Listing = {
-    id: 13,
-    user_id: 1,
-    status: ListingStatus.PENDING,
-    name: "Farmmmm",
-    description: "Description of the listing",
-    province: "Example Province",
-    city: "Example City",
-    barangay: "Example Barangay",
-    street: "Example Street",
-    zip_code: 12345,
-    price: 100.0,
-    maximum_guests: 5,
-    listable_type: "App\\Models\\Accommodation",
-    listable_id: 15,
-    created_at: new Date("2024-03-08T08:48:24.000000Z"),
-    updated_at: new Date("2024-03-08T08:48:24.000000Z"),
-    deleted_at: null,
-    media: [
-      {
-        id: 31,
-        listing_id: 13,
-        media:
-          "https://utfs.io/f/708298d7-aad9-491e-85c3-82f9cd0a79e3-g47goy.jpg",
-        created_at: "2024-03-08T08:48:24.000000Z",
-        updated_at: "2024-03-08T08:48:24.000000Z",
-        deleted_at: null
-      },
-      {
-        id: 32,
-        listing_id: 13,
-        media:
-          "https://utfs.io/f/ca88b394-c700-4cae-8176-6fe8d8b838b1-5nw4vb.png",
-        created_at: "2024-03-08T08:48:24.000000Z",
-        updated_at: "2024-03-08T08:48:24.000000Z",
-        deleted_at: null
-      },
-      {
-        id: 33,
-        listing_id: 13,
-        media:
-          "https://utfs.io/f/f5532a6f-e721-4458-9ffe-2ced484b7188-2487m.jpg",
-        created_at: "2024-03-08T08:48:24.000000Z",
-        updated_at: "2024-03-08T08:48:24.000000Z",
-        deleted_at: null
-      }
-    ],
-    user: {
-      id: 1,
-      first_name: "Aracs",
-      last_name: "Encabo",
-      email: "janedoe@example.com",
-      created_at: "2024-03-08T07:08:20.000000Z",
-      role: UserRole.HOST,
-      status: "active",
-      updated_at: ""
-    }
-  };
-  const popularListings = [dummyListing, dummyListing, dummyListing];
+const DashboardPage: React.FC = async () => {
+  const analytics = await getAdminAnalytics();
 
   return (
     <>
@@ -72,23 +13,40 @@ const DashboardPage: React.FC = () => {
         <span className="text-xl font-bold">Analytics</span>
       </div>
       <AdminAnalytics
-        usersCount={420}
-        hostsCount={50}
-        guestsCount={350}
-        adminCount={20}
-        bookingsCount={1092}
-        listingsCount={207}
-        accumulatedVal={78920}
-        approvedListings={198}
+        usersCount={
+          (analytics?.users.host ?? 0) +
+          (analytics?.users.guest ?? 0) +
+          (analytics?.users.admin ?? 0)
+        }
+        hostsCount={analytics?.users.host ?? 0}
+        guestsCount={analytics?.users.guest ?? 0}
+        adminCount={analytics?.users.admin ?? 0}
+        bookingsCount={
+          (analytics?.bookings.pending ?? 0) +
+          (analytics?.bookings.upcoming ?? 0) +
+          (analytics?.bookings.done ?? 0) +
+          (analytics?.bookings.cancelled ?? 0) +
+          (analytics?.bookings.refused ?? 0)
+        }
+        listingsCount={
+          (analytics?.listings.pending ?? 0) +
+          (analytics?.listings.active ?? 0) +
+          (analytics?.listings.refused ?? 0)
+        }
+        accumulatedVal={analytics?.bookings.value ?? 0}
+        approvedListings={analytics?.listings.active ?? 0}
       />
-      <div className="mt-10">
+      <div className="mt-12">
         <span className="text-xl font-bold">Popular Listings</span>
-        <PopularListings listings={popularListings} />
+        <PopularListings listings={analytics?.listings.popular ?? []} />
       </div>
-      <div>
+      <div className="mt-8">
         <span className="text-xl font-bold">User Traffic</span>
-        <div className="my-5 h-96">
-          <UserTrafficSection />
+        <div className="mt-3 h-96">
+          <UserTrafficSection
+            month={analytics?.users.traffic.month ?? ""}
+            users={analytics?.users.traffic.users ?? []}
+          />
         </div>
       </div>
     </>

--- a/frontend/src/app/components/admin/PopularListingCard.tsx
+++ b/frontend/src/app/components/admin/PopularListingCard.tsx
@@ -1,13 +1,26 @@
+"use client";
 import type { Listing } from "@/app/interfaces/types";
+import { getListingType } from "@/app/utils/helpers/getListingType";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import React from "react";
 
 const PopularListingCard: React.FC<{
   listing: Listing;
 }> = ({ listing }) => {
+  const router = useRouter();
+
+  function handleClick(): void {
+    router.push(
+      `/approvals/${getListingType(listing.listable_type)}/${listing.id}`
+    );
+  }
+
   return (
-    //  add redirect to approval details page on integration
-    <div className="flex cursor-pointer flex-col rounded-xl">
+    <div
+      className="flex cursor-pointer flex-col rounded-xl"
+      onClick={handleClick}
+    >
       <div className="overflow-hidden rounded-xl bg-gradient-to-t from-primary from-20% to-white">
         <div className="relative h-56 w-80 overflow-hidden rounded-xl duration-300 hover:h-[230px] hover:w-[325px] hover:opacity-80">
           <Image

--- a/frontend/src/app/components/admin/PopularListingCard.tsx
+++ b/frontend/src/app/components/admin/PopularListingCard.tsx
@@ -7,12 +7,11 @@ const PopularListingCard: React.FC<{
 }> = ({ listing }) => {
   return (
     //  add redirect to approval details page on integration
-    <div className="flex cursor-pointer flex-col rounded-2xl">
-      <div className="overflow-hidden rounded-2xl bg-gradient-to-t from-primary from-20% to-white">
-        <div className="relative h-56 w-80 overflow-hidden rounded-2xl duration-300 hover:h-[230px] hover:w-[325px] hover:opacity-80">
+    <div className="flex cursor-pointer flex-col rounded-xl">
+      <div className="overflow-hidden rounded-xl bg-gradient-to-t from-primary from-20% to-white">
+        <div className="relative h-56 w-80 overflow-hidden rounded-xl duration-300 hover:h-[230px] hover:w-[325px] hover:opacity-80">
           <Image
-            // add replace regex (follow regex of listingHeader.tsx) on integration
-            src={listing.media[0].media}
+            src={listing.media[0].media.replace(/['"]/g, "")}
             fill
             alt="listing image"
           />

--- a/frontend/src/app/components/admin/PopularListingsSection.tsx
+++ b/frontend/src/app/components/admin/PopularListingsSection.tsx
@@ -8,16 +8,24 @@ const PopularListings: React.FC<{
   const top3 = listings.slice(0, 3);
 
   return (
-    <div className="my-5 flex h-56 w-full flex-row">
-      <div className="mr-2 w-1/3">
-        <PopularListingCard listing={top3[0]} />
-      </div>
-      <div className="mr-2 w-1/3">
-        <PopularListingCard listing={top3[1]} />
-      </div>
-      <div className="w-1/3">
-        <PopularListingCard listing={top3[2]} />
-      </div>
+    <div className="mt-3 flex h-56 w-full flex-row">
+      {listings.length > 0 ? (
+        <>
+          <div className="mr-2 w-1/3">
+            <PopularListingCard listing={top3[0]} />
+          </div>
+          <div className="mr-2 w-1/3">
+            <PopularListingCard listing={top3[1]} />
+          </div>
+          <div className="w-1/3">
+            <PopularListingCard listing={top3[2]} />
+          </div>
+        </>
+      ) : (
+        <p className="text-center text-zinc-500">
+          No popular listings available.
+        </p>
+      )}
     </div>
   );
 };

--- a/frontend/src/app/components/admin/UserTrafficSection.tsx
+++ b/frontend/src/app/components/admin/UserTrafficSection.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { Spacer } from "@nextui-org/react";
 import {
   BarElement,
   CategoryScale,
@@ -11,17 +12,24 @@ import { Bar } from "react-chartjs-2";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip);
 
-const UserTrafficSection: React.FC = () => {
+interface UserTrafficSectionProps {
+  month: string;
+  users: number[];
+}
+
+const UserTrafficSection: React.FC<UserTrafficSectionProps> = ({
+  month,
+  users
+}) => {
   const dummyBarData = {
-    /* turn this into dynamic month on integration */
-    labels: Array.from({ length: 31 }, (_, i) => "April " + (i + 1)),
+    labels: Array.from(
+      { length: users.length },
+      (_, i) => `${month.split(" ")[0]} ` + (i + 1)
+    ),
     datasets: [
       {
         label: "site visits",
-        data: [
-          12, 19, 3, 5, 2, 3, 12, 19, 3, 5, 2, 3, 12, 19, 3, 5, 2, 3, 12, 19, 3,
-          5, 2, 3, 12, 19, 3, 5, 2, 3, 12
-        ],
+        data: users,
         backgroundColor: [
           "rgba(255, 34, 0, 1)",
           "rgba(255, 34, 0, 1)",
@@ -37,10 +45,9 @@ const UserTrafficSection: React.FC = () => {
   return (
     <>
       <div className="mb-2">
-        {/* turn this into dynamic month and year on integration */}
-        <span className="text-lg font-semibold">April 2024</span>
+        <span className="text-lg font-semibold">{month}</span>
       </div>
-      <div className="my-5">
+      <div className="mt-2">
         <Bar
           data={dummyBarData}
           width={400}
@@ -50,6 +57,7 @@ const UserTrafficSection: React.FC = () => {
           }}
         />
       </div>
+      <Spacer y={8} />
     </>
   );
 };

--- a/frontend/src/app/components/navbar/NavbarLinks.tsx
+++ b/frontend/src/app/components/navbar/NavbarLinks.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { NavbarPosition } from "@/app/utils/enums";
-import { Link, NavbarItem } from "@nextui-org/react";
+import { NavbarItem } from "@nextui-org/react";
 import { usePathname } from "next/navigation";
 import React from "react";
 import CalendarIcon from "../svgs/Navbar/CalendarIcon";
@@ -13,6 +13,7 @@ import ExperiencesIcon from "../svgs/Navbar/ExperiencesIcon";
 import HistoryIcon from "../svgs/Navbar/HistoryIcon";
 import DashboardIcon from "../svgs/Navbar/DashboardIcon";
 import { type NavbarProps } from "@/app/interfaces/NavbarProps";
+import Link from "next/link";
 
 const NavbarLinks: React.FC<NavbarProps> = (props) => {
   const pathname = usePathname();

--- a/frontend/src/app/interfaces/types.ts
+++ b/frontend/src/app/interfaces/types.ts
@@ -254,3 +254,29 @@ export interface CalendarDate {
     };
   };
 }
+
+export interface AdminAnalytics {
+  users: {
+    host: number;
+    guest: number;
+    admin: number;
+    traffic: {
+      month: string;
+      users: number[];
+    };
+  };
+  bookings: {
+    pending: number;
+    upcoming: number;
+    done: number;
+    cancelled: number;
+    refused: number;
+    value: number;
+  };
+  listings: {
+    pending: number;
+    active: number;
+    refused: number;
+    popular: Listing[];
+  };
+}

--- a/frontend/src/app/utils/helpers/adminHelper.ts
+++ b/frontend/src/app/utils/helpers/adminHelper.ts
@@ -1,8 +1,12 @@
 "use server";
 import config from "@/app/config/config";
-import type { JwtPayloadwithUser } from "@/app/interfaces/types";
+import type {
+  AdminAnalytics,
+  JwtPayloadwithUser
+} from "@/app/interfaces/types";
 import { jwtDecode } from "jwt-decode";
 import { cookies } from "next/headers";
+import { checkCookies } from "./userHelper";
 
 export async function loginAdmin(
   email: string,
@@ -33,4 +37,31 @@ export async function loginAdmin(
     }
   }
   return { message: "login failed" };
+}
+
+export async function getAdminAnalytics(): Promise<AdminAnalytics | undefined> {
+  try {
+    const jwt = cookies().get("jwt")?.value;
+    if (jwt === undefined) throw new Error("No JWT found in cookies.");
+
+    const user = await checkCookies();
+    if (user === null) throw new Error("No user found in cookies.");
+
+    const response = await fetch(`${config.backendUrl}/analytics`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+        Accept: "application/json"
+      }
+    });
+
+    if (!response.ok) throw new Error("Failed to fetch admin analytics.");
+
+    const data = await response.json();
+
+    return data.data as AdminAnalytics;
+  } catch (error) {
+    console.error("Failed to fetch admin analytics.", error);
+  }
 }


### PR DESCRIPTION
## Changes Made

- Modified user traffic data
- Call analytics endpoint from client
- Add admin analytics functionality to client

## Purpose

- Admins would be able to view reports about different transactions and user traffic in the app.

## Related Task/Issue

- Slack Link: https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1712892442884409
- Task Link: https://framgiaph.backlog.com/view/SBNB-46

## Screenshots

![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/f14d555a-7f77-4b32-b181-7f0d03ff22d6)
***
![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/089079ed-0eef-4271-a736-90f5cad4e401)

## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/a