### PR TITLE
Set listing status back to pending on edit

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/AccommodationController.php
+++ b/backend/app/Http/Controllers/Api/V1/AccommodationController.php
@@ -49,6 +49,7 @@ class AccommodationController extends Controller {
                 'price', 'maximum_guests',
             ]));
 
+            $listing->update(['status' => 'Pending']);
             $listing->updateMedia($listing, $request->media);
 
             return response()->json(['message' => 'Listing updated successfully'], Response::HTTP_OK);

--- a/backend/app/Models/Experience.php
+++ b/backend/app/Models/Experience.php
@@ -73,6 +73,8 @@ class Experience extends Model {
             'name', 'description', 'province', 'city', 'barangay', 'street', 'zip_code',
             'price', 'maximum_guests',
         ]));
+
+        $this->listing->update(['status' => 'Pending']);
     }
 
     private function updateListingMedia($media) {

--- a/backend/app/Models/Listing.php
+++ b/backend/app/Models/Listing.php
@@ -124,6 +124,8 @@ class Listing extends Model {
             self::applySearchFilter($query, $search);
         }
 
+        $query->orderBy('updated_at', 'desc')->orderBy('created_at', 'desc');
+
         $listings = $query->with(['listable', 'media', 'user:id,first_name,last_name,email,created_at'])
             ->paginate($perPage);
 

--- a/frontend/src/app/(host)/listings/accommodations/[id]/edit/EditListingComponent.tsx
+++ b/frontend/src/app/(host)/listings/accommodations/[id]/edit/EditListingComponent.tsx
@@ -11,9 +11,9 @@ import {
   updateAccommodation
 } from "@/app/utils/helpers/accommodation/request";
 import { useDisclosure } from "@nextui-org/react";
-import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { validateAccommodation } from "@/app/utils/helpers/accommodation/validation";
+import ApprovalModal from "@/app/components/ApprovalModal";
 
 interface EditListingComponentProps {
   listing: AccommodationListing;
@@ -22,8 +22,16 @@ interface EditListingComponentProps {
 const EditListingComponent: React.FC<EditListingComponentProps> = ({
   listing
 }) => {
-  const router = useRouter();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: deleteIsOpen,
+    onOpen: deleteOnOpen,
+    onClose: deleteOnClose
+  } = useDisclosure();
+  const {
+    isOpen: editIsOpen,
+    onOpen: editOnOpen,
+    onClose: editOnClose
+  } = useDisclosure();
   const [error, setError] = useState<Record<string, string | boolean>>({
     hasError: false,
     message: ""
@@ -68,8 +76,9 @@ const EditListingComponent: React.FC<EditListingComponentProps> = ({
       setIsLoading(true);
       const result = await updateAccommodation(listing.id, data, media);
       setIsLoading(false);
+      console.log(result.hasError);
       if (result.hasError === false) {
-        router.push(`/listings/accommodations/${listing.id}`);
+        editOnOpen();
       }
       if (result.hasError === true) {
         setError({
@@ -97,7 +106,7 @@ const EditListingComponent: React.FC<EditListingComponentProps> = ({
     <main className="flex min-h-screen w-full flex-col items-center justify-between">
       <EditListingForm
         listingid={listing.id.toString()}
-        onDelete={onOpen}
+        onDelete={deleteOnOpen}
         data={data}
         setData={setData}
         media={media}
@@ -107,10 +116,17 @@ const EditListingComponent: React.FC<EditListingComponentProps> = ({
         onPress={handleClick}
       />
       <DeleteModal
-        isOpen={isOpen}
-        onClose={onClose}
+        isOpen={deleteIsOpen}
+        onClose={deleteOnClose}
         size={"full"}
         onDelete={handleDelete}
+      />
+      <ApprovalModal
+        isOpen={editIsOpen}
+        onClose={editOnClose}
+        size={"full"}
+        id={listing.id.toString()}
+        type="accommodation"
       />
     </main>
   );

--- a/frontend/src/app/(host)/listings/experiences/[id]/edit/EditExperienceComponent.tsx
+++ b/frontend/src/app/(host)/listings/experiences/[id]/edit/EditExperienceComponent.tsx
@@ -3,7 +3,6 @@ import DeleteModal from "@/app/components/DeleteModal";
 import type { MediaUpdate } from "@/app/interfaces/AccomodationData";
 
 import { useDisclosure } from "@nextui-org/react";
-import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import type { ExperienceData } from "@/app/interfaces/ExperienceData";
 import type { ExperienceListing } from "@/app/interfaces/types";
@@ -13,6 +12,7 @@ import {
   updateExperience
 } from "@/app/utils/helpers/experience/request";
 import EditExperienceForm from "./EditExperienceForm";
+import ApprovalModal from "@/app/components/ApprovalModal";
 
 interface EditListingComponentProps {
   listing: ExperienceListing;
@@ -21,8 +21,16 @@ interface EditListingComponentProps {
 const EditExperienceComponent: React.FC<EditListingComponentProps> = ({
   listing
 }) => {
-  const router = useRouter();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: deleteIsOpen,
+    onOpen: deleteOnOpen,
+    onClose: deleteOnClose
+  } = useDisclosure();
+  const {
+    isOpen: editIsOpen,
+    onOpen: editOnOpen,
+    onClose: editOnClose
+  } = useDisclosure();
   const [error, setError] = useState<Record<string, string | boolean>>({
     hasError: false,
     message: ""
@@ -66,7 +74,7 @@ const EditExperienceComponent: React.FC<EditListingComponentProps> = ({
       const result = await updateExperience(listing.id, data, media);
       setIsLoading(false);
       if (result.hasError === false) {
-        router.push(`/listings/experiences/${listing.id}`);
+        editOnOpen();
       }
       if (result.hasError === true) {
         setError({
@@ -95,7 +103,7 @@ const EditExperienceComponent: React.FC<EditListingComponentProps> = ({
     <main className="flex min-h-screen w-full flex-col items-center justify-between">
       <EditExperienceForm
         listingid={listing.id.toString()}
-        onDelete={onOpen}
+        onDelete={deleteOnOpen}
         data={data}
         setData={setData}
         media={media}
@@ -105,10 +113,17 @@ const EditExperienceComponent: React.FC<EditListingComponentProps> = ({
         onPress={handleClick}
       />
       <DeleteModal
-        isOpen={isOpen}
-        onClose={onClose}
+        isOpen={deleteIsOpen}
+        onClose={deleteOnClose}
         size={"full"}
         onDelete={handleDelete}
+      />
+      <ApprovalModal
+        isOpen={editIsOpen}
+        onClose={editOnClose}
+        size={"full"}
+        id={listing.id.toString()}
+        type="experience"
       />
     </main>
   );


### PR DESCRIPTION
## Changes Made

- Updated backend to set the listing status back to pending once edited.
- Updated frontend to display "waiting for approval" modal.
- Updated display behavior of listings on the admin side (desc).

## Purpose

To ensure that edited listings revert to a pending status so that any changes made undergo admin review and approval before becoming active.

## Related Task/Issue

Link to the related task or issue that prompted these changes.

- [Slack Link](https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1713162482575959)
- [Task Link](https://framgiaph.backlog.com/view/SBNB-161)

## Screenshots

![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/9dcc7d0a-6314-4267-ab7a-a4fca0be8ec7)
![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/624d1f7c-a734-49bb-b973-811108b5a60a)
![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/9e3d0e65-55bf-4055-b58c-71b15f3c1084)
![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732837/c47c8ab4-2554-46c9-8ba5-a0c81c009b60)


## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/A
