### PR TITLE
make sticky booking section mobile responsive

### DIFF
--- a/frontend/src/app/(guest)/accommodations/[id]/page.tsx
+++ b/frontend/src/app/(guest)/accommodations/[id]/page.tsx
@@ -93,8 +93,8 @@ const GuestAccommodationsDetails: React.FC<
             status={accData.status}
             price={accData.price}
           />
-          <div className="flex h-fit flex-row items-start">
-            <div className="w-full">
+          <div className="flex flex-col items-start md:flex-row">
+            <div className="w-full flex-1">
               <Divider className="my-10 " />
               <span className="text-sm">{accData.description}</span>
               <Divider className="my-10 " />
@@ -105,7 +105,7 @@ const GuestAccommodationsDetails: React.FC<
                 listingType="accommodation"
               />
             </div>
-            <div className="w-90 h-90 sticky top-[30px] z-50 ml-5 block self-start pt-10">
+            <div className="mt-5 block w-full self-start md:sticky md:top-[30px] md:z-50 md:ms-5 md:mt-0 md:w-80 md:pt-10">
               {user !== undefined && user !== null ? (
                 <AccommodationBookingSticky
                   exclude={blockedDates}

--- a/frontend/src/app/(guest)/experiences/[id]/page.tsx
+++ b/frontend/src/app/(guest)/experiences/[id]/page.tsx
@@ -73,8 +73,8 @@ const GuestExperienceDetailsPage: React.FC<
             id={params.id}
             status={expData.status}
           />
-          <div className="flex h-fit flex-row items-start">
-            <div className="w-full">
+          <div className="flex flex-col items-start md:flex-row">
+            <div className="w-full flex-1">
               <Divider className="my-10 w-full" />
               <span className="text-sm">
                 <div className="flex flex-col">
@@ -89,7 +89,7 @@ const GuestExperienceDetailsPage: React.FC<
               <Divider className="my-10 w-full " />
               <ReviewSection listingId={params.id} listingType="experience" />
             </div>
-            <div className="w-90 h-90 sticky top-[30px]  ml-5 block self-start pt-10">
+            <div className="mt-5 block w-full self-start md:sticky md:top-[30px] md:z-50 md:ms-5 md:mt-0 md:w-80 md:pt-10">
               {user !== undefined && user !== null ? (
                 <ExperienceBookingSticky
                   maxGuest={expData.maximum_guests}

--- a/frontend/src/app/components/booking/AccommodationBookingSticky.tsx
+++ b/frontend/src/app/components/booking/AccommodationBookingSticky.tsx
@@ -71,7 +71,7 @@ const AccommodationBookingSticky: React.FC<AccommodationBookingStickyProps> = ({
   }, [nights, maxNights, startDateState]);
 
   return (
-    <div className="w-80">
+    <div className="w-full">
       <div className="mb-1 w-full rounded-xl border-1 border-black p-5 shadow-lg">
         <div className="mb-5">
           <span className="text-xl font-semibold"> ₱ {price} / night </span>
@@ -143,13 +143,12 @@ const AccommodationBookingSticky: React.FC<AccommodationBookingStickyProps> = ({
                   </PopoverTrigger>
                 }
               />
-              <PopoverContent className="my-2 ml-16">
+              <PopoverContent className="my-2 ms-6 md:ms-16">
                 <div className="flex justify-between">
                   <div className="self-center p-2 text-sm font-semibold">
                     Number of Guests
                   </div>
                   <div>
-                    {" "}
                     <GuestCounter
                       max={maxGuests}
                       min={1}

--- a/frontend/src/app/components/booking/DefaultSticky.tsx
+++ b/frontend/src/app/components/booking/DefaultSticky.tsx
@@ -9,23 +9,21 @@ interface DefaultStickyProps {
 }
 const DefaultSticky: React.FC<DefaultStickyProps> = ({ ForAccommodation }) => {
   return (
-    <div>
-      <div className="w-80">
-        <div className="mb-1 w-full rounded-xl border border-1 border-black p-5 shadow-lg">
-          <div className="flex w-full justify-center p-2">
-            <span className="w-full text-center text-lg font-bold">
-              You must login to book{" "}
-              {ForAccommodation ? "accommodations" : "experiences"}.
-            </span>
-          </div>
-          <DividerText>or continue using</DividerText>
-          <div className="p-2">
-            <GoogleButton
-              onPress={async () => {
-                await signIn("google");
-              }}
-            />
-          </div>
+    <div className="w-full">
+      <div className="mb-1 w-full rounded-xl border border-1 border-black p-5 shadow-lg">
+        <div className="flex w-full justify-center p-2">
+          <span className="w-full text-center text-lg font-bold">
+            You must login to book{" "}
+            {ForAccommodation ? "accommodations" : "experiences"}.
+          </span>
+        </div>
+        <DividerText>or continue using</DividerText>
+        <div className="p-2">
+          <GoogleButton
+            onPress={async () => {
+              await signIn("google");
+            }}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/app/components/booking/ExperienceBookingSticky.tsx
+++ b/frontend/src/app/components/booking/ExperienceBookingSticky.tsx
@@ -72,7 +72,7 @@ const ExperienceBookingSticky: React.FC<ExperienceBookingStickyProps> = ({
     setDateArr(newArr);
   }, [dates, endDateState, startDateState]);
   return (
-    <div className="w-96">
+    <div className="w-full">
       <div className="mb-1 w-full rounded-xl border-1 border-black p-5 shadow-lg">
         <div className="mb-5">
           <span className="text-xl font-semibold">From ₱ {price} / Person</span>


### PR DESCRIPTION
## Changes Made

- Moved sticky booking section to bottom on mobile.

## Purpose

- The page would be mobile responsive on any browser size.

## Related Task/Issue

Link to the related task or issue that prompted these changes.

Slack Link:
- To follow

Task Link:
- https://framgiaph.backlog.com/view/SBNB-154
- https://framgiaph.backlog.com/view/SBNB-155

## Screenshots

![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/b91bdefe-704c-4500-b576-c2c6911a233e) ![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/a2e8f6b2-2d12-46f2-90ee-eb9eb02b9adc) ![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/00a50ed8-8794-4448-906c-936e363511ab)

## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/A
