### PR TITLE
persist listing filters on page reload

### DIFF
--- a/frontend/src/app/components/listings/ListingSearchBar.tsx
+++ b/frontend/src/app/components/listings/ListingSearchBar.tsx
@@ -68,13 +68,15 @@ const ListingSearchBar: React.FC<ListingSearchBarProps> = ({ user, type }) => {
     },
     date: [
       {
-        startDate: (searchParams.get(`${prefix}date`)?.split(":")[0] ??
-          MIN_DATE) as Date,
+        startDate: new Date(
+          searchParams.get(`${prefix}date`)?.split(":")[0] ?? MIN_DATE
+        ),
         endDate:
           searchParams.get(`${prefix}date`) === null
             ? undefined
-            : ((searchParams.get(`${prefix}date`)?.split(":")[1] ??
-                MIN_DATE) as Date),
+            : new Date(
+                searchParams.get(`${prefix}date`)?.split(":")[1] ?? MIN_DATE
+              ),
         key: "selection"
       }
     ],
@@ -104,8 +106,6 @@ const ListingSearchBar: React.FC<ListingSearchBarProps> = ({ user, type }) => {
       filters.date[0].startDate !== MIN_DATE &&
       filters.date[0].endDate !== undefined
     ) {
-      console.log(filters.date[0].startDate);
-      console.log(filters.date[0].endDate);
       params.set(
         `${prefix}date`,
         `${formatDate(new Date(filters.date[0].startDate))}:${formatDate(new Date(filters.date[0].endDate))}`


### PR DESCRIPTION
## Changes Made

- Persist listing filters on page reload.

## Purpose

- Filters are retained even after page reload.

## Related Task/Issue

- Slack Link: https://sun-philippine.slack.com/archives/C06JZLS2W5S/p1713333229475379
- Task Link: https://framgiaph.backlog.com/view/SBNB-172

## Screenshots

![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/113862bc-7010-4a84-9957-194dbfc02bad)
![image](https://github.com/framgia/sph_sunbnb_sim/assets/156732790/b822e36b-0d34-46da-9ab1-883044dddad3)

## New Dependencies (if applicable)

N/A

## Additional Information (if applicable)

N/A
